### PR TITLE
Fix thread-safety, merge overwrites, and name parser crash

### DIFF
--- a/getmyancestors/classes/gedcom.py
+++ b/getmyancestors/classes/gedcom.py
@@ -153,8 +153,9 @@ class Gedcom:
         name = Name()
         added = False
         name.given = parts[0].strip()
-        name.surname = parts[1].strip()
-        if parts[2]:
+        if len(parts) > 1:
+            name.surname = parts[1].strip()
+        if len(parts) > 2 and parts[2]:
             name.suffix = parts[2]
         if not self.indi[self.num].name:
             self.indi[self.num].name = name

--- a/getmyancestors/classes/tree.py
+++ b/getmyancestors/classes/tree.py
@@ -2,6 +2,7 @@ import sys
 import re
 import time
 import asyncio
+import itertools
 from urllib.parse import unquote
 
 # global imports
@@ -50,14 +51,13 @@ class Note:
     :param num: the GEDCOM identifier
     """
 
-    counter = 0
+    _counter = itertools.count(1)
 
     def __init__(self, text="", tree=None, num=None):
         if num:
             self.num = num
         else:
-            Note.counter += 1
-            self.num = Note.counter
+            self.num = next(Note._counter)
         self.text = text.strip()
 
         if tree:
@@ -79,14 +79,13 @@ class Source:
     :param num: the GEDCOM identifier
     """
 
-    counter = 0
+    _counter = itertools.count(1)
 
     def __init__(self, data=None, tree=None, num=None):
         if num:
             self.num = num
         else:
-            Source.counter += 1
-            self.num = Source.counter
+            self.num = next(Source._counter)
 
         self.tree = tree
         self.url = self.citation = self.title = self.fid = None
@@ -284,14 +283,13 @@ class Indi:
     :param num: the GEDCOM identifier
     """
 
-    counter = 0
+    _counter = itertools.count(1)
 
     def __init__(self, fid=None, tree=None, num=None):
         if num:
             self.num = num
         else:
-            Indi.counter += 1
-            self.num = Indi.counter
+            self.num = next(Indi._counter)
         self.fid = fid
         self.tree = tree
         self.famc_fid = set()
@@ -508,14 +506,13 @@ class Fam:
     :param num: a GEDCOM identifier
     """
 
-    counter = 0
+    _counter = itertools.count(1)
 
     def __init__(self, husb=None, wife=None, tree=None, num=None):
         if num:
             self.num = num
         else:
-            Fam.counter += 1
-            self.num = Fam.counter
+            self.num = next(Fam._counter)
         self.husb_fid = husb if husb else None
         self.wife_fid = wife if wife else None
         self.tree = tree

--- a/getmyancestors/mergemyancestors.py
+++ b/getmyancestors/mergemyancestors.py
@@ -70,20 +70,26 @@ def main():
                 tree.indi[fid].fid = ged.indi[num].fid
             tree.indi[fid].fams_fid |= ged.indi[num].fams_fid
             tree.indi[fid].famc_fid |= ged.indi[num].famc_fid
-            tree.indi[fid].name = ged.indi[num].name
-            tree.indi[fid].birthnames = ged.indi[num].birthnames
-            tree.indi[fid].nicknames = ged.indi[num].nicknames
-            tree.indi[fid].aka = ged.indi[num].aka
-            tree.indi[fid].married = ged.indi[num].married
-            tree.indi[fid].gender = ged.indi[num].gender
-            tree.indi[fid].facts = ged.indi[num].facts
-            tree.indi[fid].notes = ged.indi[num].notes
-            tree.indi[fid].sources = ged.indi[num].sources
-            tree.indi[fid].memories = ged.indi[num].memories
-            tree.indi[fid].baptism = ged.indi[num].baptism
-            tree.indi[fid].confirmation = ged.indi[num].confirmation
-            tree.indi[fid].initiatory = ged.indi[num].initiatory
-            tree.indi[fid].endowment = ged.indi[num].endowment
+            if not tree.indi[fid].name:
+                tree.indi[fid].name = ged.indi[num].name
+            tree.indi[fid].birthnames |= ged.indi[num].birthnames
+            tree.indi[fid].nicknames |= ged.indi[num].nicknames
+            tree.indi[fid].aka |= ged.indi[num].aka
+            tree.indi[fid].married |= ged.indi[num].married
+            if not tree.indi[fid].gender:
+                tree.indi[fid].gender = ged.indi[num].gender
+            tree.indi[fid].facts |= ged.indi[num].facts
+            tree.indi[fid].notes |= ged.indi[num].notes
+            tree.indi[fid].sources |= ged.indi[num].sources
+            tree.indi[fid].memories |= ged.indi[num].memories
+            if not tree.indi[fid].baptism:
+                tree.indi[fid].baptism = ged.indi[num].baptism
+            if not tree.indi[fid].confirmation:
+                tree.indi[fid].confirmation = ged.indi[num].confirmation
+            if not tree.indi[fid].initiatory:
+                tree.indi[fid].initiatory = ged.indi[num].initiatory
+            if not tree.indi[fid].endowment:
+                tree.indi[fid].endowment = ged.indi[num].endowment
             if not (tree.indi[fid].sealing_child and tree.indi[fid].sealing_child.famc):
                 tree.indi[fid].sealing_child = ged.indi[num].sealing_child
 
@@ -98,11 +104,11 @@ def main():
             if ged.fam[num].fid:
                 tree.fam[(husb, wife)].fid = ged.fam[num].fid
             if ged.fam[num].facts:
-                tree.fam[(husb, wife)].facts = ged.fam[num].facts
+                tree.fam[(husb, wife)].facts |= ged.fam[num].facts
             if ged.fam[num].notes:
-                tree.fam[(husb, wife)].notes = ged.fam[num].notes
+                tree.fam[(husb, wife)].notes |= ged.fam[num].notes
             if ged.fam[num].sources:
-                tree.fam[(husb, wife)].sources = ged.fam[num].sources
+                tree.fam[(husb, wife)].sources |= ged.fam[num].sources
             tree.fam[(husb, wife)].sealing_spouse = ged.fam[num].sealing_spouse
 
     # merge notes by text


### PR DESCRIPTION
## Summary
- **Thread-safe counters**: Replace `Class.counter += 1` with `itertools.count()` — the class-level increment is not atomic and can produce duplicate IDs under concurrent access (e.g. ThreadPoolExecutor in notes download)
- **Merge data loss**: `mergemyancestors` overwrites individual data with `=` instead of merging with `|=` — second file stomps first file's facts, notes, sources, and memories. Fixes #72
- **Name parser crash**: `gedcom.py` assumes names always have 2+ slashes — crashes on malformed GEDCOM names without them

## Changes
- `tree.py`: `itertools.count(1)` for Note, Source, Indi, Fam counters
- `mergemyancestors.py`: `=` → `|=` for sets, `if not` guards for scalar fields
- `gedcom.py`: Length checks on `parts` before accessing `[1]` and `[2]`

## Test plan
- [ ] Run `mergemyancestors` with two overlapping GEDCOM files, verify data from both files is preserved
- [ ] Run export with `--concurrency > 1`, verify no duplicate GEDCOM IDs
- [ ] Parse GEDCOM file with names missing slash delimiters